### PR TITLE
Modernise CMakeLists.txt for scikit-build-core best practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.21)
-project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
+cmake_minimum_required(VERSION 3.21...3.31)
+project(
+  ${SKBUILD_PROJECT_NAME}
+  VERSION ${SKBUILD_PROJECT_VERSION}
+  LANGUAGES C)
 
 # Define source directory
 set(PYPOLYLINE_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/pypolyline")
@@ -56,7 +59,7 @@ elseif(UNIX)
 endif()
 
 # Install the extension module
-install(TARGETS cutil DESTINATION pypolyline)
+install(TARGETS cutil DESTINATION ${SKBUILD_PROJECT_NAME})
 
 # Install the shared library
 if(APPLE)
@@ -65,11 +68,13 @@ elseif(UNIX)
   set(POLYLINE_LIB_NAME "libpolylineffi.so")
 elseif(WIN32)
   set(POLYLINE_LIB_NAME "polylineffi.dll")
+else()
+  message(FATAL_ERROR "Unsupported platform: cannot determine polyline library name")
 endif()
 
 install(FILES ${PYPOLYLINE_SRC_DIR}/${POLYLINE_LIB_NAME}
-        DESTINATION pypolyline)
+        DESTINATION ${SKBUILD_PROJECT_NAME})
 
 # Install header file
 install(FILES ${PYPOLYLINE_SRC_DIR}/header.h
-        DESTINATION pypolyline)
+        DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 
 [tool.scikit-build]
 minimum-version = "build-system.requires"
-wheel.packages = ["src/convertbng"]
+wheel.packages = ["src/pypolyline"]
 
 [build-system]
 requires = [

--- a/tests/test_pypolyline.py
+++ b/tests/test_pypolyline.py
@@ -13,7 +13,7 @@ class PolylineTests(unittest.TestCase):
     """Tests for py_polyline"""
 
     def setUp(self):
-        """make these available to all tests"""
+        """Make these available to all tests"""
         self.coords = [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]]
         try:
             self.polyline = bytes("_p~iF~ps|U_ulLnnqC_mqNvxq`@", "utf-8")


### PR DESCRIPTION
- Use cmake_minimum_required version-range form (3.21...3.31)
- Pass SKBUILD_PROJECT_VERSION through to project()
- Use SKBUILD_PROJECT_NAME for install destinations instead of hardcoding
- Add fatal error fallback for unsupported platforms in POLYLINE_LIB_NAME