### PR TITLE
tidy CI wheel build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -109,17 +109,13 @@ jobs:
       - name: Build and Test Wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD_FRONTEND: build[uv]
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: 'pytest {package}'
           CIBW_BUILD: ${{ matrix.pybuilds }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.12
 
       - id: attest
         name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "./wheelhouse/*.whl"
 
@@ -144,8 +140,13 @@ jobs:
         fetch-depth: 0  # Optional, use if you use setuptools_scm
         submodules: true  # Optional, use if you have submodules
 
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "latest"
+
     - name: Build SDist
-      run: pipx run build --sdist
+      run: uv build --sdist
 
     - uses: actions/upload-artifact@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ testpaths = [
     "tests",
 ]
 
+[tool.cibuildwheel]
+build-frontend = "build[uv]"
+test-requires = ["pytest"]
+test-command = "pytest {package}"
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+
 [tool.ruff]
 exclude = [
     ".bzr",


### PR DESCRIPTION
Move cibuildwheel config from workflow env vars into [tool.cibuildwheel] in pyproject.toml, bump attest-build-provenance to v4, switch sdist build to uv, and raise macOS deployment target to 11.0.