### PR TITLE
CI maintenance: cache cibuildwheel interpreters and unignore dependabot actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Optional: Official actions have moving tags like v1;
-      # if you use those, you don't need updates.
-      - dependency-name: "actions/*"
 
   - package-ecosystem: "uv"
     directory: "/"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -106,9 +106,16 @@ jobs:
         with:
           version: "latest"
 
+      - name: Cache cibuildwheel interpreters
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.cibw-cache
+          key: cibw-${{ matrix.id }}-${{ hashFiles('.github/workflows/wheels.yml') }}
+
       - name: Build and Test Wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
+          CIBW_CACHE_PATH: ${{ github.workspace }}/.cibw-cache
           CIBW_BUILD: ${{ matrix.pybuilds }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}


### PR DESCRIPTION
Ports the two most recent merged PRs from the [simplification](https://github.com/urschrei/simplification) repo to this one.

## Cache cibuildwheel interpreters across CI runs (simplification#142)
Persist `CIBW_CACHE_PATH` with `actions/cache` so the per-version CPython downloads are reused between runs instead of re-fetched every build.

## Stop ignoring actions/* in dependabot (simplification#143)
The ignore rule suppressed all updates for GitHub-owned actions on the assumption that moving major tags suffice. Moving tags only track within a major, so cross-major bumps (e.g. the Node 20 -> 24 runtime change in actions/cache v5) were never proposed. Removing it lets dependabot raise those under the existing github-actions updates.