### PR TITLE
Update cibuildwheel to v4.0.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,7 +113,7 @@ jobs:
           key: cibw-${{ matrix.id }}-${{ hashFiles('.github/workflows/wheels.yml') }}
 
       - name: Build and Test Wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v4.0.0
         env:
           CIBW_CACHE_PATH: ${{ github.workspace }}/.cibw-cache
           CIBW_BUILD: ${{ matrix.pybuilds }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,14 @@ test-command = "pytest {package}"
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
+[tool.cibuildwheel.windows]
+# cibuildwheel 4.0.0 runs delvewheel by default on Windows. We already bundle
+# polylineffi.dll next to the extension module via CMake, and it is resolved at
+# runtime from the module's own directory, so the repair step is unnecessary and
+# fails because delvewheel does not search the wheel's package directory for
+# polylineffi.dll.
+repair-wheel-command = ""
+
 [tool.ruff]
 exclude = [
     ".bzr",


### PR DESCRIPTION
Bumps the build action to `pypa/cibuildwheel@v4.0.0` and skips the Windows repair step.

cibuildwheel 4.0.0 runs `delvewheel` by default on Windows, but `polylineffi.dll` is already bundled next to the extension module via CMake and resolved at runtime from the module's own directory. delvewheel does not search the wheel's package directory for it, so the repair step is unnecessary and fails — hence `[tool.cibuildwheel.windows] repair-wheel-command = ""`.

Mirrors the same change made in `simplification`.