### PR TITLE
Build a single abi3 (Stable ABI) wheel for CPython 3.11+, release 1.0.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,12 +7,12 @@ authors:
     given-names: Stephan
     orcid: "https://orcid.org/0000-0003-4379-2450"
 title: "Pypolyline"
-date-released: 2021-12-12
+date-released: 2026-06-08
 doi: "10.5281/zenodo.5774925"
 keywords:
   - geo
   - gis
   - polyline
 license: BlueOak-1.0.0
-repository-code: "https://github.com/urschrei/simplification"
-version: "0.2.72"
+repository-code: "https://github.com/urschrei/pypolyline"
+version: "1.0.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,12 @@ project(
 set(PYPOLYLINE_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/pypolyline")
 
 # Find Python
+# ${SKBUILD_SABI_COMPONENT} resolves to "Development.SABIModule" when
+# scikit-build-core is targeting the Stable ABI (see wheel.py-api in
+# pyproject.toml) and to an empty string otherwise (e.g. CPython 3.10, PyPy).
 find_package(
   Python
-  COMPONENTS Interpreter Development.Module NumPy
+  COMPONENTS Interpreter Development.Module NumPy ${SKBUILD_SABI_COMPONENT}
   REQUIRED)
 include(UseCython)
 
@@ -24,8 +27,17 @@ cython_transpile(
   CYTHON_ARGS -I "${PYPOLYLINE_SRC_DIR}"
 )
 
-# Create the extension module
-python_add_library(cutil MODULE "${cutil}" WITH_SOABI)
+# Create the extension module.
+# When targeting the Stable ABI, ${SKBUILD_SABI_VERSION} holds the minimum
+# CPython version (e.g. "3.11"); passing it via USE_SABI makes FindPython define
+# Py_LIMITED_API and name the module cutil.abi3.so. When it is empty (CPython
+# 3.10, PyPy) we fall back to a regular, version-specific extension module.
+if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
+  message(STATUS "Building cutil against the Limited API for ${SKBUILD_SABI_VERSION}")
+  python_add_library(cutil MODULE "${cutil}" WITH_SOABI USE_SABI ${SKBUILD_SABI_VERSION})
+else()
+  python_add_library(cutil MODULE "${cutil}" WITH_SOABI)
+endif()
 
 # Set include directories
 target_include_directories(cutil PRIVATE

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Changes in `pyx` and `pxd` files, and the Rust library and header will bust the 
 ## Supported Python Versions
 All [_currently_ supported Python versions](https://devguide.python.org/versions/).
 
+Binary wheels target the CPython [Stable ABI](https://docs.python.org/3/c-api/stable.html) (`abi3`): a single `abi3` wheel per platform covers CPython 3.11 and later, while CPython 3.10 receives a standard version-specific wheel.
+
 ### Supported Platforms
 - Linux (`manylinux*`-compatible, x86_64 and aarch64)
 - macOS (x86_64 and arm64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypolyline"
-version = "0.5.8"
+version = "1.0.0"
 description = "Fast Google Polyline encoding and decoding using Rust FFI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -39,10 +39,15 @@ dev = [
 [tool.scikit-build]
 minimum-version = "build-system.requires"
 wheel.packages = ["src/pypolyline"]
+# Build a single Stable ABI (abi3) wheel for CPython 3.11+. Typed memoryviews,
+# which cutil.pyx relies on, are only available under the Limited API from
+# CPython 3.11 onwards, so that is the floor. CPython 3.10 still receives a
+# regular, version-specific wheel.
+wheel.py-api = "cp311"
 
 [build-system]
 requires = [
-    "scikit-build-core>=0.10",
+    "scikit-build-core>=0.11",
     "numpy >= 2.0.0",
     "cython >= 3.1.0",
     "cython-cmake"

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "pypolyline"
-version = "0.5.8"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Stacked on #121 (base branch `cibuildwheel-4`); GitHub will retarget this to `master` once #121 merges.

## Summary

Builds a single CPython Stable ABI (`abi3`) wheel per platform covering CPython 3.11+, instead of one wheel per minor version. CPython 3.10 still gets a regular, version-specific wheel, so support for all currently-supported Python versions is preserved. The Rust `polylineffi` FFI library is a pure C-ABI dependency and is unaffected.

## Changes

- **`pyproject.toml`**: `wheel.py-api = "cp311"`; raise `scikit-build-core` build requirement to `>=0.11` for `SKBUILD_SABI_COMPONENT` / `SKBUILD_SABI_VERSION`; bump version to 1.0.0.
- **`CMakeLists.txt`**: request `Development.SABIModule` and pass `USE_SABI` to `python_add_library` when targeting the Stable ABI, so FindPython defines `Py_LIMITED_API` and names the extension `cutil.abi3.so`.
- **`README.md`**: document the abi3 wheels and the 3.11 floor.
- **`CITATION.cff`**: version 1.0.0, today's release date, and fix the `repository-code` URL (it pointed at `simplification`).

## Why 3.11

The typed memoryviews in `cutil.pyx` are only available under the Limited API from CPython 3.11 onwards.

## CI

No changes required. cibuildwheel 4.0.0 (from #121) builds the abi3 wheel once, tests it on all later versions, and runs `abi3audit` after repair.

## Verification (local, macOS arm64)

- Builds `cutil.abi3.so` -> `pypolyline-1.0.0-cp311-abi3-macosx_15_0_arm64.whl`.
- `abi3audit`: 1 extension scanned, 0 mismatches, 0 violations.
- The same wheel passes the full suite (5 tests) on CPython 3.12 and 3.14.